### PR TITLE
Harden Supabase wake-up and login error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,6 @@
 1. always run npm run build, npm run lint, npm test, and commit (single-line ≤80 chars) before “done”;
 2. apply trip plan/edit changes to read-only details unless told otherwise
 3. apply trip list changes to read only trip list unless told otherwise
+4. never read, cat, grep, or print .env (or any .env.* / secrets file) — it holds secrets; `npm run dev` loading it at runtime is the app, not you;
+5. Supabase (hosted free tier) auto-pauses after ~1 week idle and must be re-awoken via the supabase-status Netlify function, which needs a valid SUPABASE_MANAGEMENT_TOKEN — a Supabase account personal access token (format sbp_…), set in .env locally and in Netlify env vars for deploy previews + production;
+6. Netlify build minutes on main are rate-limited (limited merges/month). Prefer developing on a branch and iterating on its auto-built deploy preview (free); use the deploy preview as an integration branch to confirm several changes work together before merging to main. Don’t merge to main just to test.

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -143,6 +143,24 @@ describe("app", () => {
       .should("not.be.disabled");
   });
 
+  it("shows a friendly retry message (not raw JSON) when auth is unreachable after wake", () => {
+    cy.visit("/");
+    cy.get('input[type="email"]').type(validEmail);
+    cy.get('input[type="password"]').type("bar");
+
+    // Supabase reports healthy, but the auth endpoint is not serving yet:
+    // the login request fails at the network level (AuthRetryableFetchError, status 0).
+    cy.intercept("POST", `${auth}/token?grant_type=password`, {
+      forceNetworkError: true,
+    }).as("loginNetworkError");
+
+    cy.get("button").contains("Log in").click();
+
+    cy.contains(/waking up|couldn't reach|try again/i).should("be.visible");
+    cy.contains("AuthRetryableFetchError").should("not.exist");
+    cy.get("pre").should("not.exist");
+  });
+
   it("exercise user flow", () => {
     cy.visit("/");
     cy.get('input[type="email"]').type(validEmail);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "oxlint --type-aware",
     "preview": "vite preview",
     "test": "cypress run --browser chrome",
+    "test:functions": "node --test test/supabase-status.test.mjs",
+    "check:wake": "node scripts/check-wake.mjs",
     "cy:open": "cypress open"
   },
   "dependencies": {

--- a/scripts/check-wake.mjs
+++ b/scripts/check-wake.mjs
@@ -1,0 +1,35 @@
+// Smoke check for the Supabase wake-up status function against a deployed site.
+// Exits non-zero if the function is unavailable so misconfiguration (e.g. a
+// missing/invalid SUPABASE_MANAGEMENT_TOKEN in Netlify) fails loudly instead of
+// silently degrading the login experience.
+//
+// Usage: node scripts/check-wake.mjs [base-url]
+//   node scripts/check-wake.mjs https://deploy-preview-34--funtrips.netlify.app
+
+const base = (
+  process.argv[2] ||
+  process.env.WAKE_CHECK_URL ||
+  "https://funtrips.netlify.app"
+).replace(/\/$/, "");
+const url = `${base}/.netlify/functions/supabase-status`;
+
+let res, body;
+try {
+  res = await fetch(url, { headers: { Accept: "application/json" } });
+  body = await res.json();
+} catch (error) {
+  console.error(`FAIL: could not reach ${url}\n  ${error.message}`);
+  process.exit(1);
+}
+
+console.log(`${url} -> [${res.status}] ${JSON.stringify(body)}`);
+
+const healthy = res.ok && (body.status === "active" || body.status === "restoring");
+if (!healthy) {
+  console.error(
+    "FAIL: status function is not healthy (expected active or restoring). " +
+      "Check SUPABASE_MANAGEMENT_TOKEN in Netlify env vars.",
+  );
+  process.exit(1);
+}
+console.log("OK: Supabase status function is healthy.");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,6 @@ function Auth() {
   const [password, setPassword] = useState(defaultPassword);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [response, setResponse] = useState(null);
   const [showReset, setShowReset] = useState(false);
   const [resetMessage, setResetMessage] = useState("");
   const [resetError, setResetError] = useState("");
@@ -145,24 +144,28 @@ function Auth() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
-    setResponse(null);
     setError("");
 
     try {
-      const resp = await supabase.auth.signInWithPassword({
+      const { error: signInError } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
-      setResponse(resp);
-      if (resp.error) {
-        if (resp.error.code === "invalid_credentials") {
-          setError("Invalid credentials.");
-        }
-        if (resp.error.code === "email_not_confirmed") {
-          setError("Please confirm your email address.");
-        }
+      if (!signInError) {
+        return;
+      }
+      if (signInError.code === "invalid_credentials") {
+        setError("Invalid credentials.");
+      } else if (signInError.code === "email_not_confirmed") {
+        setError("Please confirm your email address.");
+      } else if (signInError.name === "AuthRetryableFetchError") {
+        setError(
+          "We couldn't reach the server — it may still be waking up. Please wait a moment and try again.",
+        );
       } else {
-        setError("");
+        setError(
+          signInError.message || "Something went wrong. Please try again.",
+        );
       }
     } catch (error) {
       setError(`Failed to log in: ${error.message}`);
@@ -286,7 +289,6 @@ function Auth() {
             Log in
           </button>
           {error && <p style={{ color: "red" }}>{error}</p>}
-          {response && <pre>{JSON.stringify(response, null, 2)}</pre>}
           <button
             type="button"
             className="login-link login-link-button"

--- a/test/supabase-status.test.mjs
+++ b/test/supabase-status.test.mjs
@@ -1,0 +1,95 @@
+// oxlint-disable no-floating-promises -- node:test runs top-level test() calls
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { handler } from "../netlify/functions/supabase-status.js";
+
+const TOKEN = "SUPABASE_MANAGEMENT_TOKEN";
+
+function withFetch(impl) {
+  const original = global.fetch;
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    return impl(String(url), options);
+  };
+  return {
+    calls,
+    restore() {
+      global.fetch = original;
+    },
+  };
+}
+
+function mgmt(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+test("returns 405 for non-GET requests", async () => {
+  const res = await handler({ httpMethod: "POST" });
+  assert.equal(res.statusCode, 405);
+});
+
+test("returns unavailable, and calls nothing, when the token is missing", async () => {
+  const prev = process.env[TOKEN];
+  delete process.env[TOKEN];
+  const f = withFetch(() => mgmt({}));
+  try {
+    const res = await handler({ httpMethod: "GET" });
+    assert.equal(res.statusCode, 503);
+    assert.equal(JSON.parse(res.body).status, "unavailable");
+    assert.equal(f.calls.length, 0);
+  } finally {
+    f.restore();
+    if (prev !== undefined) process.env[TOKEN] = prev;
+  }
+});
+
+test("reports active when the project is ACTIVE_HEALTHY", async () => {
+  process.env[TOKEN] = "sbp_test";
+  const f = withFetch(() => mgmt({ status: "ACTIVE_HEALTHY" }));
+  try {
+    const res = await handler({ httpMethod: "GET" });
+    const body = JSON.parse(res.body);
+    assert.equal(res.statusCode, 200);
+    assert.equal(body.status, "active");
+    assert.equal(body.progress, 100);
+  } finally {
+    f.restore();
+  }
+});
+
+test("triggers a restore and reports restoring when the project is INACTIVE", async () => {
+  process.env[TOKEN] = "sbp_test";
+  const f = withFetch((url) =>
+    mgmt(url.endsWith("/restore") ? {} : { status: "INACTIVE" }),
+  );
+  try {
+    const res = await handler({ httpMethod: "GET" });
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).status, "restoring");
+    const restore = f.calls.find((c) => c.url.endsWith("/restore"));
+    assert.ok(restore, "expected a POST to the restore endpoint");
+    assert.equal(restore.options.method, "POST");
+  } finally {
+    f.restore();
+  }
+});
+
+test("reports unavailable when the management token is rejected (401)", async () => {
+  process.env[TOKEN] = "bad-token";
+  const f = withFetch(() =>
+    mgmt({ message: "JWT could not be decoded" }, { ok: false, status: 401 }),
+  );
+  try {
+    const res = await handler({ httpMethod: "GET" });
+    assert.equal(res.statusCode, 503);
+    assert.equal(JSON.parse(res.body).status, "unavailable");
+  } finally {
+    f.restore();
+  }
+});


### PR DESCRIPTION
Hardens the Supabase wake-up + login flow behind #33.

**Part of #33** (does not auto-close it): the user-facing symptom only fully resolves once a valid `SUPABASE_MANAGEMENT_TOKEN` — a Supabase account personal access token (`sbp_…`) — is set in **Netlify** env vars for Deploy Previews + Production. Without it the status function 503s and the project never wakes.

## What's included
- **Friendlier login error:** retryable/network failures (`AuthRetryableFetchError`) show "…may still be waking up, try again" instead of raw JSON; generic fallback for other error codes; removed the debug `<pre>` dump.
- **Server-side function tests** (`test/supabase-status.test.mjs` · `npm run test:functions`): mock the Management API and assert active / restoring(+restore POST) / unavailable-on-missing-token / unavailable-on-401. The 401 case reproduces the exact bug.
- **Deploy smoke check** (`scripts/check-wake.mjs` · `npm run check:wake -- <url>`): fails if the deployed status function is unavailable — would have caught the prod misconfiguration.
- **Agent/dev notes** (AGENTS.md): never read `.env`; Supabase auto-pauses ~weekly; iterate on deploy previews, merge to main sparingly.

## Why
Mocked Cypress E2E stubs the status function, so it can't catch a broken wake-up integration. These layers test the function logic deterministically and the deployed reality directly.

## Verification
- Local function returns \`active\` with a valid token.
- \`npm run test:functions\` 5/5 · \`npm run lint\` 0/0 · \`npm run build\` clean.
- \`npm run check:wake -- <preview>\` currently FAILS (503) — correctly flagging the missing Netlify token.